### PR TITLE
Feat/#2 report review

### DIFF
--- a/src/main/java/app/global/config/JacksonConfig.java
+++ b/src/main/java/app/global/config/JacksonConfig.java
@@ -1,0 +1,20 @@
+package app.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+	@Bean
+	public ObjectMapper objectMapper() {
+		ObjectMapper mapper = new ObjectMapper();
+		mapper.registerModule(new JavaTimeModule());
+		mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);  // 숫자 타임스탬프 → 문자열 ISO 형식
+		return mapper;
+	}
+}
+

--- a/src/main/java/app/global/config/WebClientConfig.java
+++ b/src/main/java/app/global/config/WebClientConfig.java
@@ -1,4 +1,4 @@
-package app.report.config;
+package app.global.config;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -11,9 +11,13 @@ import java.time.Duration;
 @Configuration
 public class WebClientConfig {
 	@Bean
-	public WebClient reportWebClient(@Value("${report.python.base-url}") String baseUrl,
-		@Value("${report.python.timeout:60s}") Duration timeout) {
-		var http = HttpClient.create().responseTimeout(timeout);
+	public WebClient reportWebClient(
+		@Value("${report.python.base-url}") String baseUrl,
+		@Value("${report.python.timeout:60s}") Duration timeout
+	) {
+		HttpClient http = HttpClient.create()
+			.responseTimeout(timeout);
+
 		return WebClient.builder()
 			.baseUrl(baseUrl)
 			.clientConnector(new ReactorClientHttpConnector(http))

--- a/src/main/java/app/report/model/dto/request/ReportGenerationRequest.java
+++ b/src/main/java/app/report/model/dto/request/ReportGenerationRequest.java
@@ -3,7 +3,8 @@ package app.report.model.dto.request;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
 
 public record ReportGenerationRequest(
 	String storeId,
@@ -18,9 +19,11 @@ public record ReportGenerationRequest(
 		String paymentMethod,
 		String orderStatus,
 		String requestMessage,   // nullable
+		@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS")
 		LocalDateTime createdAt,
 		String storeName,
 		String usersex,           // nullable
+		@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
 		LocalDate birthdate,     // nullable
 		boolean isFirstOrderInStore,
 		int orderSeqInStore,
@@ -37,6 +40,7 @@ public record ReportGenerationRequest(
 	public record ReviewRow(
 		int rating,
 		String content,
+		@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS")
 		LocalDateTime createdAt
 	) {}
 }


### PR DESCRIPTION
1. JacksonConfig 추가: JavaTimeModule 등록 및 WRITE_DATES_AS_TIMESTAMPS 비활성화
    → LocalDate/LocalDateTime을 전역적으로 ISO-8601 문자열로 직렬화
2. ReportGenerationRequest 필드(createdAt, birthdate)에 @JsonFormat 적용
    → 전역 설정 보조 안전망으로 필드별 포맷도 명시
3. Spring → Python 통신 시 날짜 포맷 불일치로 발생하던 422 오류 해결