### PR TITLE
Refactor(report) : Lambda Function URL 사용

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,10 @@ jwt:
 server:
   port: 8090
 
+#aws:
+#  region: ap-northeast-2
+
 report:
   python:
-    base-url: http://localhost:8091
+    base-url: ${LAMBDA_FUNCTION_URL}
     timeout: 60s


### PR DESCRIPTION
1. application.yml: base-url로 Lambda Function URL 사용

## 🔥 Related Issues

- close #이슈번호

## 👍 작업 내용

- Lambda 호출을 위해 함수 URL 사용
   (SigV4 암호화 필터 적용하지 않음 -> 함수 URL의 인증 유형이 None임)

## ✅ PR Point

- 
## 📚 Reference**
**
- 구현에 참고한 링크 (필요한 경우만 작성하고 없으면 지우기)
